### PR TITLE
Random codebook

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from PIL import Image
+from vector_quantization.metrics import PSNR
+from vector_quantization.image import load_image, save_image
+from vector_quantization.codebooks import random_codebook
+from vector_quantization.quantization import quantize
+
+if __name__ == "__main__":
+
+    img = load_image("balloon.bmp")
+    quantized_img = quantize(img, window_size=4, codebook_fun=random_codebook, codebook_size=32)
+    Image.fromarray(quantized_img).show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pytz==2020.1
 PyYAML==5.3.1
 regex==2020.10.15
 six==1.15.0
+timebudget==0.7.1
 toml==0.10.1
 typed-ast==1.4.1
 typing-extensions==3.7.4.3

--- a/tests/test_codebooks.py
+++ b/tests/test_codebooks.py
@@ -1,0 +1,17 @@
+import unittest
+import numpy as np
+import numpy.testing as npt
+
+from vector_quantization.codebooks import random_codebook
+
+
+class TestRandomCodebook(unittest.TestCase):
+    def test_random_codebook(self):
+        vectors = np.array([[1, 1], [2, 2], [1, 1], [3, 3], [4, 4], [1, 1]])
+        codebook = random_codebook(vectors, 4)
+        codebook = np.array(codebook)
+        print(codebook)
+        self.assertTrue([1, 1] in codebook)
+        self.assertTrue([2, 2] in codebook)
+        self.assertTrue([3, 3] in codebook)
+        self.assertTrue([4, 4] in codebook)

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,28 @@
+import unittest
+import numpy as np
+import numpy.testing as npt
+
+from vector_quantization.quantization import find_closest, quantize_from_codebook
+
+
+class TestFindClosest(unittest.TestCase):
+    def test_find_closest(self):
+        codebook = np.array([[1, 1, 1], [2, 2, 2], [5, 5, 5]])
+        vector = np.array([2.5, 2.5, 2.5])
+        closest = find_closest(vector, codebook)
+
+        npt.assert_almost_equal(closest, np.array([2, 2, 2]))
+
+
+class TestQuantizeFromCodebook(unittest.TestCase):
+    def test_quantize(self):
+        from vector_quantization.codebooks import random_codebook
+        from vector_quantization.vectorize import vectorize, image_from_vectors
+
+        codebook = np.array([[1, 1, 1, 1], [2, 2, 2, 2], [5, 5, 5, 5]])
+        image = np.array([[1, 1, 3, 3], [1, 1, 3, 3], [4, 4, 0, 0], [4, 4, 0, 0]])
+        vectors = vectorize(image, 2)
+        quantized_vectors = quantize_from_codebook(vectors, codebook)
+        quantized_image = image_from_vectors(quantized_vectors, image)
+        expected_quantized_image = np.array([[1, 1, 2, 2], [1, 1, 2, 2], [5, 5, 1, 1], [5, 5, 1, 1]])
+        npt.assert_almost_equal(quantized_image, expected_quantized_image)

--- a/vector_quantization/codebooks.py
+++ b/vector_quantization/codebooks.py
@@ -1,0 +1,11 @@
+import random
+import numpy as np
+from timebudget import timebudget
+
+
+@timebudget
+def random_codebook(vectors, length=512):
+    codebook = random.sample(np.unique(vectors, axis=0).tolist(), length)
+    # Following line is 2 times faster but creates codebook with possible duplicates
+    # codebook = random.sample(vectors.tolist(), length)
+    return codebook

--- a/vector_quantization/image_noiser.py
+++ b/vector_quantization/image_noiser.py
@@ -1,5 +1,5 @@
 from metrics import PSNR
-from image import load_image, save_image
+from vectot_quantization.image import load_image, save_image
 
 
 def add_noise(original_image):

--- a/vector_quantization/quantization.py
+++ b/vector_quantization/quantization.py
@@ -1,0 +1,45 @@
+import numpy as np
+import timeit
+from timebudget import timebudget
+
+from vector_quantization.vectorize import vectorize, image_from_vectors
+
+
+@timebudget
+def quantize(image, window_size, codebook_fun, codebook_size, verbose=False):
+    quantized_img = image.copy()
+    vectors = vectorize(quantized_img, window_size=window_size)
+    codebook = codebook_fun(vectors, length=codebook_size)
+
+    quantized_vectors = quantize_from_codebook(vectors, codebook)
+
+    quantized_img = image_from_vectors(quantized_vectors, quantized_img)
+    return quantized_img
+
+
+@timebudget
+def quantize_from_codebook(vectors, codebook):
+    quantized_vectors = np.zeros_like(vectors)
+    for idx, vector in enumerate(vectors):
+        quantized_vectors[idx, :] = find_closest(vector, codebook)
+    return quantized_vectors
+
+
+def find_closest(vector, codebook):
+    # TODO: optimize
+    # Probably it will be faster to calculate distances for all vectors
+    dists = np.sum(np.sqrt((codebook - vector) ** 2), axis=1)
+    closest_id = np.argmin(dists)
+    closest = codebook[closest_id]
+    return closest
+
+
+if __name__ == "__main__":
+    from PIL import Image
+    from metrics import PSNR
+    from image import load_image, save_image
+    from codebooks import random_codebook
+
+    img = load_image("balloon.bmp")
+    quantized_img = quantize(img, window_size=4, codebook_fun=random_codebook, codebook_size=32)
+    Image.fromarray(quantized_img).show()

--- a/vector_quantization/vectorize.py
+++ b/vector_quantization/vectorize.py
@@ -29,6 +29,17 @@ def vectorize(img, window_size):
     return vectors
 
 
+def image_from_vectors(vectors, image):
+    height, width = image.shape
+    index = 0
+    ws = int(np.sqrt(vectors[0].size))
+    for i in range(height // ws):
+        for j in range(width // ws):
+            image[i * ws : i * ws + ws, j * ws : j * ws + ws].flat = vectors[index, :]
+            index += 1
+    return image
+
+
 if __name__ == "__main__":
     from image import load_image
 


### PR DESCRIPTION
Running application with `python main.py` performs quantization using random codebook.

![image](https://user-images.githubusercontent.com/3882385/97119228-25240d00-170f-11eb-976a-62e1f9378a50.png)

Quantization takes quite long time. With `codebook_size` of only 32 quantization of balloon takes almost 3 seconds. We should fix that in the next PR.